### PR TITLE
Add chat status indicators and stabilize composer layout

### DIFF
--- a/app/assets/stylesheets/components/_chat.scss
+++ b/app/assets/stylesheets/components/_chat.scss
@@ -155,3 +155,154 @@
   from { transform: translateY(2px); opacity: 0; }
   to   { transform: translateY(0);   opacity: 1; }
 }
+
+/* ========== PureComm minimal thinking indicator (pc-*) ========== */
+#pc-thinking[hidden] { display: none; }
+#pc-thinking {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 10px; border-radius: 10px;
+  background: #f6f6ff; color: #2b2b55; font-size: 0.9rem;
+  transition: opacity 120ms ease;
+}
+
+.pc-dots { display: inline-flex; gap: 3px; }
+.pc-dots i {
+  width: 6px; height: 6px; border-radius: 50%; background: currentColor;
+  opacity: .25; animation: pcDots 1.1s infinite ease-in-out; display: inline-block;
+}
+.pc-dots i:nth-child(2){ animation-delay: .15s; }
+.pc-dots i:nth-child(3){ animation-delay: .3s; }
+@keyframes pcDots { 0%,60%,100%{ transform: translateY(0); opacity:.25 } 30%{ transform: translateY(-4px); opacity:.95 } }
+#pc-thinking[hidden] { display: none; opacity: 0; }
+
+/* PureComm tiny error badge */
+#pc-error[hidden] { display: none; }
+#pc-error {
+  display: inline-flex; gap: 8px; align-items: center; flex-wrap: wrap;
+  margin-top: 6px; padding: 8px 10px; border-radius: 10px;
+  background: #fff4f4; border: 1px solid #ffd4d4; color: #611; font-size: 0.9rem;
+}
+
+/* --- Status strip inside footer --- */
+.chat-composer .chat-status {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;      /* reserve space so the form doesn't jump */
+  margin: 6px 0 10px;    /* small gap above the form */
+}
+
+.chat-composer .chat-status > div[hidden] {
+  display: none !important;
+}
+/* === restore message box size (only) === */
+#new_message { display: block; width: 100%; }
+#message_form { display: block; width: 100%; }
+
+#message_content {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 72px;      /* same height you had before */
+  border: 1px solid var(--chat-border);
+  border-radius: var(--radius-lg);
+  background: var(--chat-surface);
+  color: var(--chat-text);
+  padding: .75rem .9rem;
+}
+
+#message_content:focus {
+  outline: none;
+  border: 2px solid var(--user-border);
+  box-shadow: 0 0 0 3px rgba(255, 209, 102, 0.3);
+}
+
+/* === keep Send on the right (clean) === */
+#message_form .actions [type="submit"] {
+  margin-left: auto !important;  /* pushes it to the far right */
+  width: auto !important;        /* never 100% */
+  display: inline-flex;          /* avoid block-level full width */
+}
+
+/* === stable status strip above form === */
+#new_message .chat-status {
+  min-height: 28px;         /* reserve space so layout doesn't jump */
+  margin-bottom: 6px;       /* little gap above textarea */
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#new_message .chat-status > div[hidden] {
+  display: none !important;
+}
+
+/* === Freeze composer with a 2-row grid: [status | form] === */
+#new_message {
+  display: grid !important;
+  grid-template-rows: 28px auto !important; /* fixed status row, then form */
+  gap: 6px !important;
+  width: 100%;
+}
+
+/* Status row (stays 28px high whether hidden or not) */
+#new_message .chat-status {
+  grid-row: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;    /* matches the fixed row */
+}
+#new_message .chat-status > div[hidden] {
+  display: none !important;
+}
+
+/* Form fills the second row, full width */
+#message_form {
+  grid-row: 2;
+  width: 100%;
+}
+
+/* Textarea stays full width / original height */
+#message_content {
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 72px;
+}
+
+/* Keep Send on the right */
+#message_form .actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  width: 100%;
+}
+#message_form .actions [type="submit"] {
+  margin-left: auto;
+  width: auto;
+  display: inline-flex;
+}
+
+/* === restore Send button look + position === */
+#message_form .actions {
+  display: flex !important;
+  justify-content: flex-end !important;
+  align-items: center;
+  width: 100%;
+}
+
+#message_form .actions .btn-primary {
+  background: var(--user-border) !important;   /* yellow background */
+  border-color: var(--user-border) !important;
+  color: #222 !important;
+  font-weight: 600 !important;
+  width: auto !important;
+  margin-left: auto !important;                /* push to right */
+  display: inline-flex !important;
+}
+
+#message_form .actions .btn-primary:hover {
+  background: #fbcf5c !important;
+  border-color: #fbcf5c !important;
+}

--- a/app/javascript/controllers/compose_controller.js
+++ b/app/javascript/controllers/compose_controller.js
@@ -5,6 +5,7 @@ export default class extends Controller {
 
   connect() {
     // focus when the form appears
+    console.log("[compose] connect fired")
     this.textareaTarget?.focus()
   }
 
@@ -24,5 +25,64 @@ export default class extends Controller {
       // Trigger submit button
       this.submitTarget?.click()
     }
+  }
+
+  // --- Minimal helpers to toggle the tiny thinking badge ---
+  pcThinkingEl() {
+    return document.getElementById("pc-thinking")
+  }
+
+  showThinking() {
+    this._pcThinkingStartedAt = performance.now()
+    const el = this.pcThinkingEl()
+    if (el) el.hidden = false
+  }
+
+  hideThinking() {
+    const el = this.pcThinkingEl()
+    if (!el) return
+
+    const MIN_MS = 800  // minimum time to keep it visible
+    const started = this._pcThinkingStartedAt || performance.now()
+    const elapsed = performance.now() - started
+    const wait = Math.max(0, MIN_MS - elapsed)
+
+    setTimeout(() => { el.hidden = true }, wait)
+  }
+
+  // --- Minimal helpers for error badge ---
+  pcErrorEl() {
+    return document.getElementById("pc-error")
+  }
+
+  pcErrorDetailEl() {
+    return document.getElementById("pc-error-detail")
+  }
+
+  hideError() {
+    const box = this.pcErrorEl()
+    if (!box) return
+    box.hidden = true
+    const d = this.pcErrorDetailEl()
+    if (d) d.textContent = ""
+  }
+
+  showError(msg) {
+    const box = this.pcErrorEl()
+    if (!box) return
+    const d = this.pcErrorDetailEl()
+    if (d) d.textContent = msg || ""
+    box.hidden = false
+  }
+  checkStatus(event) {
+  const { success, fetchResponse } = event.detail || {}
+  if (success) return  // everything was fine
+
+  let msg = "Please try again."
+  if (fetchResponse && fetchResponse.response) {
+    const r = fetchResponse.response
+    msg = `Error ${r.status} ${r.statusText || ""}`.trim()
+  }
+  this.showError(msg)
   }
 }

--- a/app/views/messages/_error_badge.html.erb
+++ b/app/views/messages/_error_badge.html.erb
@@ -1,0 +1,4 @@
+<div id="pc-error" hidden>
+  <strong>Something went wrong.</strong>
+  <span id="pc-error-detail"></span>
+</div>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: [partnership, message],
               data: { controller: "compose",
-                      action: "turbo:submit-end->compose#reset" },
+                      action: "turbo:submit-start->compose#hideError turbo:submit-start->compose#showThinking turbo:submit-end->compose#hideThinking turbo:submit-error->compose#hideThinking turbo:submit-end->compose#reset turbo:submit-end->compose#checkStatus" },
               id: "message_form" do |f| %>
   <div class="field">
     <%= f.text_area :content,

--- a/app/views/messages/_thinking_badge.html.erb
+++ b/app/views/messages/_thinking_badge.html.erb
@@ -1,0 +1,5 @@
+<!-- Tiny, namespaced, and hidden by default -->
+<div id="pc-thinking" hidden>
+  <span class="pc-dots"><i></i><i></i><i></i></span>
+  <span>Coach is thinking…</span>
+</div>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -5,12 +5,23 @@
   <header class="chat-header">
     <h1 class="chat-title">Coach Chat</h1>
   </header>
-  <!-- Messages -->
+  <!-- Messages (ONE container, ONE id) -->
   <div id="messages" data-controller="autoscroll" class="chat-messages">
     <%= render @messages %>
   </div>
-  <!-- Composer -->
+  <!-- Status strip (thinking + error badges go here) -->
+  <div class="chat-status">
+    <%= render "messages/thinking_badge" %>
+    <%= render "messages/error_badge" %>
+  </div>
+  <!-- Composer (ONE footer, ONE id) -->
   <footer class="chat-composer" id="new_message">
-    <%= render partial: "messages/form", locals: { partnership: @partnership, message: @message } %>
+    <!-- Status strip lives inside the footer now -->
+    <div class="chat-status">
+      <%= render "messages/thinking_badge" %>
+      <%= render "messages/error_badge" %>
+    </div>
+    <%= render partial: "messages/form",
+               locals: { partnership: @partnership, message: @message } %>
   </footer>
 </section>


### PR DESCRIPTION
- Added "Coach is thinking…" badge with animated dots
- Added error badge to display failed chat submissions
- Wired Stimulus actions (showThinking, hideThinking, hideError, checkStatus)
- Reserved fixed status strip above message form to prevent layout jumps
- Restored consistent textarea size and styling
- Pinned Send button to the right and restored yellow theme